### PR TITLE
Improve error handling when deletions fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10.0rc1-alpine
 
 RUN apk add build-base
 
-RUN pip install httpx dateparser
+RUN pip install httpx dateparser --user
 
 COPY main.py /main.py
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ jobs:
           account-type: org
           org-name: my-org
           token: ${{ secrets.PAT }}
-  
+
       - name: Delete 'test' containers older than a month
         uses: sondrelg/container-retention-policy@v0.1
         with:

--- a/main_tests.py
+++ b/main_tests.py
@@ -24,6 +24,7 @@ from main import parse_image_names, validate_inputs
 
 mock_response = Mock()
 mock_response.json.return_value = []
+mock_response.is_error = False
 mock_http_client = AsyncMock()
 mock_http_client.get.return_value = mock_response
 mock_http_client.delete.return_value = mock_response
@@ -92,7 +93,7 @@ class TestGetAndDeleteOldVersions:
             parsed_cutoff=parse('an hour ago utc'), timestamp_type=TimestampType('created_at'), account_type=AccountType('personal')
         )
 
-        await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=AsyncMock())
+        await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=mock_http_client)
         captured = capsys.readouterr()
         assert captured.out == 'Deleted old image: a:1234567\n'
 
@@ -111,7 +112,7 @@ class TestGetAndDeleteOldVersions:
             parsed_cutoff=parse('2 days ago utc'), timestamp_type=TimestampType('created_at'), account_type=AccountType('personal')
         )
 
-        await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=AsyncMock())
+        await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=mock_http_client)
         captured = capsys.readouterr()
         assert captured.out == 'No more versions to delete for a\n'
 
@@ -122,7 +123,7 @@ class TestGetAndDeleteOldVersions:
             parsed_cutoff=parse('an hour ago utc'), timestamp_type=TimestampType('created_at'), account_type=AccountType('personal')
         )
 
-        await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=AsyncMock())
+        await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=mock_http_client)
         captured = capsys.readouterr()
         assert captured.out == 'Skipping image version 1234567. Unable to parse timestamps.\nNo more versions to delete for a\n'
 
@@ -133,7 +134,7 @@ class TestGetAndDeleteOldVersions:
             parsed_cutoff=parse('an hour ago utc'), timestamp_type=TimestampType('created_at'), account_type=AccountType('personal')
         )
 
-        await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=AsyncMock())
+        await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=mock_http_client)
         captured = capsys.readouterr()
         assert captured.out == 'No more versions to delete for a\n'
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -316,15 +316,26 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "tzdata"
+version = "2021.1"
+description = "Provider of IANA time zone data"
+category = "main"
+optional = false
+python-versions = ">=2"
+
+[[package]]
 name = "tzlocal"
-version = "2.1"
+version = "3.0"
 description = "tzinfo object for the local timezone"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-pytz = "*"
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+test = ["pytest-mock (>=3.3)", "pytest (>=4.3)"]
 
 [metadata]
 lock-version = "1.1"
@@ -525,7 +536,11 @@ types-dateparser = [
     {file = "types-dateparser-1.0.0.tar.gz", hash = "sha256:2ab180bddf23349ade7861d67c9abc9e22b9de8a7ae5981ed9e40e441750c51f"},
     {file = "types_dateparser-1.0.0-py3-none-any.whl", hash = "sha256:1a14ad04159eada9e57caa53abdadb3a1524227a3e8627e47f165a7ddb60cd20"},
 ]
+tzdata = [
+    {file = "tzdata-2021.1-py2.py3-none-any.whl", hash = "sha256:9ad21eada54c97001e3e9858a674b3ee6bebe4a4fb2b58465930f2af0ba6c85d"},
+    {file = "tzdata-2021.1.tar.gz", hash = "sha256:e19c7351f887522a1ac739d21041e592ddde6dd1b764fdefa8f7b2b3551d3d38"},
+]
 tzlocal = [
-    {file = "tzlocal-2.1-py2.py3-none-any.whl", hash = "sha256:e2cb6c6b5b604af38597403e9852872d7f534962ae2954c7f35efcb1ccacf4a4"},
-    {file = "tzlocal-2.1.tar.gz", hash = "sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44"},
+    {file = "tzlocal-3.0-py3-none-any.whl", hash = "sha256:c736f2540713deb5938d789ca7c3fc25391e9a20803f05b60ec64987cf086559"},
+    {file = "tzlocal-3.0.tar.gz", hash = "sha256:f4e6e36db50499e0d92f79b67361041f048e2609d166e93456b50746dc4aef12"},
 ]


### PR DESCRIPTION
Using `raise_for_status` hides the *actually pretty useful* Github API responses 👏 

PR switches over to just printing the response and response code outright.