### PR TITLE
Add new parameters for filtering by tags

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,2 +1,0 @@
-FROM scratch
- CMD ["$RANDOM"]

--- a/README.md
+++ b/README.md
@@ -165,6 +165,21 @@ with access to the container registry. Specifically, you need to grant it the fo
 - `read:packages`, and
 - `delete:packages`
 
+## untagged-only:
+
+* **Required**: `No`
+* **Default**: `false`
+
+Restricts image deletion to images without any tags, if enabled.
+
+
+## skip-tags:
+
+* **Required**: `No`
+* **Example**: `latest`
+
+Restrict deletions to images without specific tags, if specified.
+
 # Nice to knows
 
 * The Github API restricts ut to fetching 100 image versions per image name, so if your registry isn't 100% clean after

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,13 @@ inputs:
   token:
     description: 'Personal access token with read and delete scopes.'
     required: true
+  untagged-only:
+    description: 'Restrict deletions to images without tags.'
+    required: false
+    default: 'false'
+  skip-tags:
+    description: 'Restrict deletions to images without specific tags.'
+    required: false
 
 runs:
   using: 'docker'
@@ -35,3 +42,5 @@ runs:
     - ${{ inputs.timestamp-to-use }}
     - ${{ inputs.cut-off }}
     - ${{ inputs.token }}
+    - ${{ inputs.untagged-only }}
+    - ${{ inputs.skip-tags }}

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections import namedtuple
 from dataclasses import dataclass
+from distutils.util import strtobool
 from enum import Enum
 from functools import partial
 from sys import argv
@@ -203,7 +204,7 @@ def validate_inputs(
         raise ValueError('org-name is required when account-type is org')
 
     if isinstance(untagged_only, str):
-        untagged_only_ = bool(untagged_only)
+        untagged_only_ = strtobool(untagged_only) == 1
     else:
         untagged_only_ = untagged_only
 

--- a/main_tests.py
+++ b/main_tests.py
@@ -1,6 +1,6 @@
+from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from functools import partial
-from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
 import pytest as pytest
@@ -16,15 +16,18 @@ from main import (
     delete_org_package_versions,
     delete_package_versions,
     get_and_delete_old_versions,
+    get_image_version_tags,
     list_org_package_versions,
     list_package_versions,
 )
 from main import main as main_
-from main import parse_image_names, validate_inputs
+from main import parse_image_names, post_deletion_output, validate_inputs
 
 mock_response = Mock()
 mock_response.json.return_value = []
 mock_response.is_error = False
+mock_bad_response = Mock()
+mock_bad_response.is_error = True
 mock_http_client = AsyncMock()
 mock_http_client.get.return_value = mock_response
 mock_http_client.delete.return_value = mock_response
@@ -50,9 +53,25 @@ async def test_delete_package_version():
     await delete_package_versions(image_name=ImageName('test', 'test'), http_client=mock_http_client, version_id=123)
 
 
+def test_post_deletion_output(capsys):
+    # Happy path
+    post_deletion_output(mock_response, image_name=ImageName('test', 'test'), version_id=123)
+    captured = capsys.readouterr()
+    assert captured.out == 'Deleted old image: test:123\n'
+
+    # Bad response
+    post_deletion_output(mock_bad_response, image_name=ImageName('test', 'test'), version_id=123)
+    captured = capsys.readouterr()
+    assert captured.out != 'Deleted old image: test:123\n'
+
+
 def test_inputs_dataclass():
     personal = Inputs(
-        parsed_cutoff=parse('an hour ago utc'), timestamp_type=TimestampType('created_at'), account_type=AccountType('personal')
+        parsed_cutoff=parse('an hour ago utc'),
+        timestamp_type=TimestampType('created_at'),
+        account_type=AccountType('personal'),
+        untagged_only=False,
+        skip_tags=[],
     )
     assert personal.is_org is False
     assert personal.list_package_versions == list_package_versions
@@ -63,84 +82,149 @@ def test_inputs_dataclass():
         timestamp_type=TimestampType('created_at'),
         account_type=AccountType('org'),
         org_name='abcorp',
+        untagged_only=False,
+        skip_tags=[],
     )
     assert org.is_org is True
     assert isinstance(org.list_package_versions, partial)
     assert isinstance(org.delete_package, partial)
 
 
+def test_get_image_version_tags():
+    assert (
+        get_image_version_tags(
+            {
+                'metadata': {'container': {'tags': []}},
+            }
+        )
+        == []
+    )
+    assert (
+        get_image_version_tags(
+            {
+                'metadata': {'container': {'tags': ['a']}},
+            }
+        )
+        == ['a']
+    )
+    assert get_image_version_tags({'metadata': {}}) == []
+
+
 class TestGetAndDeleteOldVersions:
+    valid_data = [
+        {
+            'created_at': '2021-05-26T14:03:03Z',
+            'html_url': 'https://github.com/orgs/org-name/packages/container/image-name/1234567',
+            'id': 1234567,
+            'metadata': {'container': {'tags': []}, 'package_type': 'container'},
+            'name': 'sha256:3c6891187412bd31fa04c63b4f06c47417eb599b1b659462632285531aa99c19',
+            'package_html_url': 'https://github.com/orgs/org-name/packages/container/package/image-name',
+            'updated_at': '2021-05-26T14:03:03Z',
+            'url': 'https://api.github.com/orgs/org-name/packages/container/image-name/versions/1234567',
+        }
+    ]
+    valid_inputs = {
+        'parsed_cutoff': parse('an hour ago utc'),
+        'timestamp_type': TimestampType('created_at'),
+        'account_type': AccountType('personal'),
+        'untagged_only': False,
+        'skip_tags': [],
+    }
+
     @staticmethod
-    async def mock_list_package_versions(data, *args):
+    async def _mock_list_package_versions(data, *args):
         return data
 
     @pytest.mark.asyncio
-    async def test_get_and_delete_old_versions_delete_package_scenario(self, capsys):
-        data = [
-            {
-                'created_at': '2021-05-26T14:03:03Z',
-                'html_url': 'https://github.com/orgs/org-name/packages/container/image-name/1234567',
-                'id': 1234567,
-                'metadata': {'container': {'tags': []}, 'package_type': 'container'},
-                'name': 'sha256:3c6891187412bd31fa04c63b4f06c47417eb599b1b659462632285531aa99c19',
-                'package_html_url': 'https://github.com/orgs/org-name/packages/container/package/image-name',
-                'updated_at': '2021-05-26T14:03:03Z',
-                'url': 'https://api.github.com/orgs/org-name/packages/container/image-name/versions/1234567',
-            }
-        ]
-        Inputs.list_package_versions = partial(self.mock_list_package_versions, data)
-        inputs = Inputs(
-            parsed_cutoff=parse('an hour ago utc'), timestamp_type=TimestampType('created_at'), account_type=AccountType('personal')
-        )
+    async def test_delete_package(self, capsys):
+        Inputs.list_package_versions = partial(self._mock_list_package_versions, self.valid_data)
+        inputs = Inputs(**self.valid_inputs)
 
         await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=mock_http_client)
+
         captured = capsys.readouterr()
         assert captured.out == 'Deleted old image: a:1234567\n'
 
     @pytest.mark.asyncio
-    async def test_get_and_delete_old_versions_not_old_enough_scenario(self, capsys):
+    async def test_not_beyond_cutoff(self, capsys):
+        data = [
+            {
+                'created_at': str(datetime.now(timezone(timedelta(hours=1)))),
+                'id': 1234567,
+            }
+        ]
+
         Inputs.list_package_versions = partial(
-            self.mock_list_package_versions,
-            [
-                {
-                    'created_at': str(datetime.now(timezone(timedelta(hours=1)))),
-                    'id': 1234567,
-                }
-            ],
+            self._mock_list_package_versions,
+            data,
         )
-        inputs = Inputs(
-            parsed_cutoff=parse('2 days ago utc'), timestamp_type=TimestampType('created_at'), account_type=AccountType('personal')
-        )
+        inputs = Inputs(**self.valid_inputs)
 
         await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=mock_http_client)
+
         captured = capsys.readouterr()
         assert captured.out == 'No more versions to delete for a\n'
 
     @pytest.mark.asyncio
-    async def test_get_and_delete_old_versions_skip_package_scenario(self, capsys):
-        Inputs.list_package_versions = partial(self.mock_list_package_versions, [{'created_at': '', 'id': 1234567}])
-        inputs = Inputs(
-            parsed_cutoff=parse('an hour ago utc'), timestamp_type=TimestampType('created_at'), account_type=AccountType('personal')
-        )
+    async def test_missing_timestamp(self, capsys):
+        data = [{'created_at': '', 'id': 1234567}]
+
+        Inputs.list_package_versions = partial(self._mock_list_package_versions, data)
+        inputs = Inputs(**self.valid_inputs)
 
         await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=mock_http_client)
+
         captured = capsys.readouterr()
         assert captured.out == 'Skipping image version 1234567. Unable to parse timestamps.\nNo more versions to delete for a\n'
 
     @pytest.mark.asyncio
-    async def test_get_and_delete_old_versions_no_packages_scenario(self, capsys):
-        Inputs.list_package_versions = partial(self.mock_list_package_versions, [])
-        inputs = Inputs(
-            parsed_cutoff=parse('an hour ago utc'), timestamp_type=TimestampType('created_at'), account_type=AccountType('personal')
-        )
+    async def test_empty_list(self, capsys):
+        data = []
+
+        Inputs.list_package_versions = partial(self._mock_list_package_versions, data)
+        inputs = Inputs(**self.valid_inputs)
 
         await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=mock_http_client)
+
+        captured = capsys.readouterr()
+        assert captured.out == 'No more versions to delete for a\n'
+
+    @pytest.mark.asyncio
+    async def test_skip_tags(self, capsys):
+        data = deepcopy(self.valid_data)
+        data[0]['metadata'] = {'container': {'tags': ['abc', 'bcd']}}
+
+        Inputs.list_package_versions = partial(self._mock_list_package_versions, data)
+        inputs = Inputs(**self.valid_inputs | {'skip_tags': 'abc'})
+
+        await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=mock_http_client)
+
+        captured = capsys.readouterr()
+        assert captured.out == 'No more versions to delete for a\n'
+
+    @pytest.mark.asyncio
+    async def test_untagged_only(self, capsys):
+        data = deepcopy(self.valid_data)
+        data[0]['metadata'] = {'container': {'tags': ['abc', 'bcd']}}
+
+        Inputs.list_package_versions = partial(self._mock_list_package_versions, data)
+        inputs = Inputs(**self.valid_inputs | {'untagged_only': 'true'})
+
+        await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=mock_http_client)
+
         captured = capsys.readouterr()
         assert captured.out == 'No more versions to delete for a\n'
 
 
 def test_inputs_bad_account_type():
-    defaults = {'account_type': 'org', 'org_name': 'test', 'timestamp_type': 'updated_at', 'cut_off': '2 hours ago UTC'}
+    defaults = {
+        'account_type': 'org',
+        'org_name': 'test',
+        'timestamp_type': 'updated_at',
+        'cut_off': '2 hours ago UTC',
+        'untagged_only': False,
+        'skip_tags': None,
+    }
 
     # Account type
     validate_inputs(**defaults | {'account_type': 'personal'})
@@ -166,6 +250,18 @@ def test_inputs_bad_account_type():
         validate_inputs(**defaults | {'cut_off': '12/12/12'})
     with pytest.raises(ValueError, match="Unable to parse 'lolol'"):
         validate_inputs(**defaults | {'cut_off': 'lolol'})
+
+    # Untagged only
+    for i in ['true', 'True', '1']:
+        assert validate_inputs(**defaults | {'untagged_only': i}).untagged_only is True
+    for j in ['False', 'false', '0']:
+        assert validate_inputs(**defaults | {'untagged_only': j}).untagged_only is False
+    assert validate_inputs(**defaults | {'untagged_only': False}).untagged_only is False
+
+    # Skip tags
+    assert validate_inputs(**defaults | {'skip_tags': 'a'}).skip_tags == ['a']
+    assert validate_inputs(**defaults | {'skip_tags': 'a,b'}).skip_tags == ['a', 'b']
+    assert validate_inputs(**defaults | {'skip_tags': 'a , b  ,c'}).skip_tags == ['a', 'b', 'c']
 
 
 def test_parse_image_names():


### PR DESCRIPTION
This way you can choose to only clean up untagged images if you enable `untagged-only`, or you can do the same for specific tags, by specifying `skip-tags: my-important-tag, and-my-other-important-tag`.

This shouldn't change any backward compatibility (not that anyone is using this atm), but think I'll just bump to v1.1 unless you have any feedback @JonasKs 